### PR TITLE
Moved StartLimitIntervalSec to the proper service section

### DIFF
--- a/debian/systemd/evok.service
+++ b/debian/systemd/evok.service
@@ -6,6 +6,7 @@ Conflicts=mervisconfigtool.service
 After=neurontcp.service
 After=unipitcp.service
 After=pigpio.service
+StartLimitIntervalSec=300
 
 [Service]
 Type=simple
@@ -18,7 +19,6 @@ ExecStopPost=-/bin/rm -f /etc/evok-nginx.conf
 ExecStopPost=-/bin/mv -f /etc/nginx/sites-enabled/evok /etc/nginx/sites-available/
 ExecStopPost=-/bin/cp -f /etc/nginx/sites-available/mervis /etc/nginx/sites-enabled/
 ExecStopPost=-/bin/rm -f /etc/nginx/sites-enabled/evok
-StartLimitIntervalSec=300
 TimeoutStopSec=3
 SyslogLevel=debug
 SyslogIdentifier=evok

--- a/etc/systemd/system/evok.service
+++ b/etc/systemd/system/evok.service
@@ -2,11 +2,11 @@
 Description=Evok Modbus/Websocket/Rpc Server
 Requires=pigpio.service
 Requires=neurontcp.service
+StartLimitIntervalSec=300
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/python /opt/evok/evok.py
-StartLimitIntervalSec=300
 TimeoutStopSec=3
 SyslogLevel=debug
 SyslogIdentifier=evok


### PR DESCRIPTION
According to the documentation (and to my logs), [`StartLimitIntervalSec`](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#StartLimitIntervalSec=interval) must be part of the [`Unit`](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#[Unit]%20Section%20Options)
section.