### PR TITLE
Updated initial version string for UniPi 1.0

### DIFF
--- a/evok/config.py
+++ b/evok/config.py
@@ -15,7 +15,7 @@ except:
     pass
 
 up_globals = {
-    'version': "1.0",
+    'version': "UniPi 1.0",
     'devices': {
         'ai': {
             '1': 5.564920867,


### PR DESCRIPTION
Set the init version string from "1.0" to "UniPi 1.0". For some reason my UniPi is not detected correctly (have a (very) first gen). On my UniPi the var config.up_globals was filled with "1.0" but should be filled with "UniPi 1.0". In my case the AnalogOutput was not working correctly. Value 10 sends 0V and value 1 sends 9V (0 = 10V). On my UniPi the value must be distracted from 10 to get the correct output voltage.