### PR TITLE
Rework device_info circuit

### DIFF
--- a/docs/circuit.md
+++ b/docs/circuit.md
@@ -5,26 +5,28 @@ The circuit is created automatically during initialization of Evok according to 
 
 **Circuit creation table:**
 
-| Device type name    | Key            | Circuit format                                  | Examples                          |
-|---------------------|----------------|-------------------------------------------------|-----------------------------------|
-| Relay               | *ro*           | <device_name\>_<number\>                        | `2_01`, `xS11_02`                 |
-| Digital Output      | *do*           | <device_name\>_<number\>                        | `1_01`, `1_02`                    |
-| Digital Input       | *di*           | <device_name\>_<number\>                        | `1_01`, `xS11_02`                 |
-| Analog Output       | *ao*           | <device_name\>_<number\>                        | `1_01`, `xS51_02`                 |
-| Analog Input        | *ai*           | <device_name\>_<number\>                        | `1_01`, `xS51_02`                 |
-| User LED            | *led*          | <device_name\>_<number\>                        | `1_01`, `2_02`                    |
-| Master Watchdog     | *wd*           | <device_name\>_<number\>                        | `1_01`, `1_02`                    |
-| 1-Wire bus          | *owbus*        | <device_name\>                                  | `1`                               |
-| 1-Wire power        | *owpower*      | <device_name\>                                  | `1`                               |
-| Temp sensor         | *temp*         | <1-Wire_address\>                               | `2895DCD509000035`                | 
-| Non-volatile memory | *nvsave*       | <device_name\>                                  | `1`, `2`, `xS51`                  |
-| Modbus slave        | *modbus_slave* | <device_name\>                                  | `1`, `2`, `IAQ`                   |
-| Device info         | *device_info*  | <family_name\>\_<device_name\>_<serial_number\> | `Neuron_L533_0`, `Patron_S167_81` |
-| Data point          | *data_point*   | <device_name\>_<register_address\>              | `IAQ_0`, `IAQ_6`, `IAQ_10`        |
-| Modbus register     | *register*     | <device_name\>_<register_address\>              | `1_0`, `1_1`, `1_1000`            |
+| Device type name    | Key            | Circuit format                                    | Examples                   |
+|---------------------|----------------|---------------------------------------------------|----------------------------|
+| Relay               | *ro*           | <device_name\>_<number\>                          | `2_01`, `xS11_02`          |
+| Digital Output      | *do*           | <device_name\>_<number\>                          | `1_01`, `1_02`             |
+| Digital Input       | *di*           | <device_name\>_<number\>                          | `1_01`, `xS11_02`          |
+| Analog Output       | *ao*           | <device_name\>_<number\>                          | `1_01`, `xS51_02`          |
+| Analog Input        | *ai*           | <device_name\>_<number\>                          | `1_01`, `xS51_02`          |
+| User LED            | *led*          | <device_name\>_<number\>                          | `1_01`, `2_02`             |
+| Master Watchdog     | *wd*           | <device_name\>_<number\>                          | `1_01`, `1_02`             |
+| 1-Wire bus          | *owbus*        | <device_name\>                                    | `1`                        |
+| 1-Wire power        | *owpower*      | <device_name\>                                    | `1`                        |
+| Temp sensor         | *temp*         | <1-Wire_address\>                                 | `2895DCD509000035`         | 
+| Non-volatile memory | *nvsave*       | <device_name\>                                    | `1`, `2`, `xS51`           |
+| Modbus slave        | *modbus_slave* | <device_name\>                                    | `1`, `2`, `IAQ`            |
+| Device info         | *device_info*  | <model_name\> (grouped) / <device_name\> (single) | `L533`, `S167`, `xS51`     |
+| Data point          | *data_point*   | <device_name\>_<register_address\>                | `IAQ_0`, `IAQ_6`, `IAQ_10` |
+| Modbus register     | *register*     | <device_name\>_<register_address\>                | `1_0`, `1_1`, `1_1000`     |
 
 - *<device_name\>*: Name defined in [Evok configuration].
     - examples: `1`, `2`, `3`, `IAQ`, `xS51`, `xS18`.
+- *<model_name\>*: Name defined in device_info configuration section.
+  - examples: `L523`, `S103`, `S167`.
 - *<number\>*: Sequence number (is based on the 'count' parameter in the [HW definition]).
     - examples: `01`, `02`, `03`, `04`, `05`, `06`, `10`, `11`, `12`.
 - *<1-Wire_address\>*: 1-Wire device address without dots.

--- a/evok/config.py
+++ b/evok/config.py
@@ -70,7 +70,7 @@ class SerialBusDevice:
 
 
 class DeviceInfo:
-    def __init__(self, family: str, model: str, sn: Union[None, int], board_count: int):
+    def __init__(self, name: str, family: str, model: str, sn: Union[None, int], board_count: int):
         """
         :param family: [Neuron, Patron, UNIPI1, Iris]
         :param model: [S103, M533, ...]
@@ -81,7 +81,7 @@ class DeviceInfo:
         self.model: str = model
         self.sn: Union[None, int] = sn
         self.board_count: int = board_count
-        self.circuit: str = f"{family}_{model}_{sn}"
+        self.circuit: str = f"{name}"
 
     def full(self):
         return {
@@ -224,7 +224,7 @@ def create_devices(evok_config: EvokConfig, hw_dict):
                 model = bus_device_info_data.get("model", 'unknown')
                 sn = bus_device_info_data.get("sn", None)
                 board_count = bus_device_info_data.get("board_count", 1)
-                bus_device_info = DeviceInfo(family=family, model=model, sn=sn, board_count=board_count)
+                bus_device_info = DeviceInfo(name=model, family=family, model=model, sn=sn, board_count=board_count)
                 Devices.register_device(DEVICE_INFO, bus_device_info)
 
         if 'devices' not in bus_data:
@@ -264,7 +264,7 @@ def create_devices(evok_config: EvokConfig, hw_dict):
                     Devices.register_device(MODBUS_SLAVE, slave)
 
                     if bus_device_info is None or "device_info" in device_data:
-                        device_info = {'model': device_name}
+                        device_info = {'model': device_data.get("model", device_name)}
                         device_info.update(device_data.get("device_info", {}))
                         family = device_info.get("family", 'unknown')
                         model = device_info.get("model", 'unknown')
@@ -273,7 +273,8 @@ def create_devices(evok_config: EvokConfig, hw_dict):
                         if model[:2].lower() in ['xs', 'xm', 'xl', 'xg'] and family == 'unknown':
                             family = 'Extension'
                         Devices.register_device(DEVICE_INFO,
-                                                DeviceInfo(family=family, model=model, sn=sn, board_count=board_count))
+                                                DeviceInfo(name=device_name, family=family, model=model, sn=sn,
+                                                           board_count=board_count))
 
                 else:
                     logger.error(f"Unknown bus type: '{bus_type}'! skipping...")


### PR DESCRIPTION
Device info circuit is linked to family, model and serial number. However, these are also device parameters and some are optional. For this reason it is not appropriate to use them for the circuit.