### PR TITLE
RPC: Return 'Invalid params' error on Invalid circuit.

### DIFF
--- a/evok/devices.py
+++ b/evok/devices.py
@@ -6,6 +6,7 @@ import re
 from copy import deepcopy
 from typing import Any, Callable, Union
 
+from .errors import DeviceNotFound
 from .log import logger
 
 """
@@ -181,7 +182,7 @@ class DeviceList(dict):
             if circuit in self.aliases:
                 return self.aliases[circuit]
             else:
-                raise Exception(f'Invalid device circuit number {str(circuit)} with devtypeid {devtype_name}')
+                raise DeviceNotFound(f"Invalid device circuit '{str(circuit)}' with devtypeid '{devtype_name}'")
 
     def by_name(self, devtype, circuit=None):
         try:
@@ -325,3 +326,4 @@ unit_altnames = {
     'mA': 'miliampere',
     'Ohm': 'ohm'
 }
+

--- a/evok/errors.py
+++ b/evok/errors.py
@@ -3,3 +3,8 @@ class ModbusSlaveError(Exception):
 
 class ENoCacheRegister(ModbusSlaveError):
     pass
+
+
+class DeviceNotFound(Exception):
+    pass
+


### PR DESCRIPTION
Modified the return error in case of non-existent device to ['Invalid params' (code -32602)](https://www.jsonrpc.org/specification#error_object).