### PR TITLE
Fix: Enable WebSocket updates for custom Modbus register devices

### DIFF
--- a/evok/modbus_slave.py
+++ b/evok/modbus_slave.py
@@ -450,6 +450,7 @@ class Board(object):
             else:
                 _reg = Register("%s_%d" % (self.circuit, board_val_reg + counter), self, counter,
                                 board_val_reg + counter, major_group=self.major_group, legacy_mode=self.legacy_mode)
+            self.__register_eventable_device(_reg)
             Devices.register_device(REGISTER, _reg)
             counter+=1
 
@@ -1186,6 +1187,12 @@ class Register:
         self.legacy_mode = legacy_mode
         self.valreg = reg
         self.reg_type = reg_type
+        self._cached_value = None
+
+    async def check_new_data(self):
+        old_value = self._cached_value
+        self._cached_value = self.regvalue()
+        return old_value != self._cached_value
 
     def regvalue(self):
         try:
@@ -1212,6 +1219,8 @@ class Register:
 
     @property
     def value(self):
+        if self._cached_value is not None:
+            return self._cached_value
         try:
             if self.regvalue():
                 return self.regvalue()


### PR DESCRIPTION
## Fix: Enable WebSocket updates for custom Modbus register devices

### Closes #214

## Problem

Modbus register devices (e.g., temperature sensors connected via RS485) were not sending value updates via WebSocket, even though:
- Values could be successfully read via REST API
- Communication with the device was working correctly
- Other device types (AI, DI, RO, etc.) were sending updates as expected

This was a regression from Evok v2, where Modbus register updates were transmitted correctly.

### Root Cause

The `Register` class was missing the necessary infrastructure to participate in the event notification system:
1. No `check_new_data()` method to detect value changes
2. Not registered as an "eventable device" during initialization
3. No cached value tracking for change detection

As a result, the periodic scan loop would read register values but never detect changes or notify WebSocket clients.

## Solution

This PR adds the missing event notification infrastructure to the `Register` class:

### Changes Made

1. **Added value caching** (`_cached_value`)
   - Stores the last read value for comparison

2. **Implemented `check_new_data()` method**
   - Compares current value with cached value
   - Returns `True` when a change is detected
   - Updates the cached value for next comparison

3. **Registered Register devices as eventable**
   - Added `self.__register_eventable_device(_reg)` in `parse_feature_register()`
   - Ensures Register devices are included in the scan loop's change detection

4. **Updated `value` property**
   - Now uses cached value when available for consistency
   - Falls back to reading from hardware if cache is empty

### Technical Details

The fix follows the same pattern used by other eventable devices (`DigitalInput`, `DataPoint`, etc.):
- Store previous value
- Compare on each scan cycle
- Notify via WebSocket when changes occur